### PR TITLE
fix(landing-screen): handle empty data case in loading state

### DIFF
--- a/frontend/screens/landing-screen.tsx
+++ b/frontend/screens/landing-screen.tsx
@@ -36,7 +36,7 @@ export const LandingScreen: FC = () => {
     if (loading) {
       return <LoadingWarehouseProducts itemsCount={5} />;
     }
-    if (!data) {
+    if (!data || data.length === 0) {
       return <EmptyWarehouse />;
     }
     return null;


### PR DESCRIPTION
## Why is this change required

This change is required because backend return empty array so condition `!data` is `false` after successful response.

## What changed
- Check if `data.length===0` in landing screen
